### PR TITLE
FIX: uninitialized constant Jobs::Jobs::Base on migrate_memberships_p…

### DIFF
--- a/app/jobs/onceoff/migrate_memberships_plugin.rb
+++ b/app/jobs/onceoff/migrate_memberships_plugin.rb
@@ -1,5 +1,5 @@
 module Jobs
-    class MigrateMembershipsPlugin < Jobs::Onceoff
+    class MigrateMembershipsPlugin < ::Jobs::Onceoff
       # Migrate content from discourse_league name to procourse_memberships
       def execute_onceoff(args)
           dl_row_presence = PluginStoreRow.where(plugin_name: "discourse_league").exists?

--- a/lib/procourse_memberships/engine.rb
+++ b/lib/procourse_memberships/engine.rb
@@ -17,11 +17,11 @@ module ProcourseMemberships
       require_dependency 'current_user_serializer'
       class ::CurrentUserSerializer
         attributes :groups
-      end 
+      end
 
       module ::Jobs
 
-        class SubscriptionCanceled < Jobs::Base
+        class SubscriptionCanceled < ::Jobs::Base
           def execute(args)
             subscription = PluginStoreRow.where(plugin_name: "procourse_memberships")
               .where("key LIKE 's:%'")
@@ -63,7 +63,7 @@ module ProcourseMemberships
           end
         end
 
-        class SubscriptionChargedUnsuccessfully < Jobs::Base
+        class SubscriptionChargedUnsuccessfully < ::Jobs::Base
           def execute(args)
             subscription = PluginStoreRow.where(plugin_name: "procourse_memberships")
               .where("key LIKE 's:%'")
@@ -105,7 +105,7 @@ module ProcourseMemberships
           end
         end
 
-        class SubscriptionChargedSuccessfully < Jobs::Base
+        class SubscriptionChargedSuccessfully < ::Jobs::Base
           def execute(args)
             subscription = PluginStoreRow.where(plugin_name: "procourse_memberships")
               .where("key LIKE 's:%'")


### PR DESCRIPTION
the problem was in adding the plugin on discourse app
- engine.rb:24:in `<module:Jobs>': uninitialized constant Jobs::Jobs::Base
- engine.rb:66:in `<module:Jobs>': uninitialized constant Jobs::Jobs::Base
- engine.rb:108:in `<module:Jobs>': uninitialized constant Jobs::Jobs::Base
- migrate_memberships_plugin.rb:2:in `<module:Jobs>': uninitialized constant Jobs::Jobs::Base